### PR TITLE
Fix prompt behavior to add new files

### DIFF
--- a/etags-update.el
+++ b/etags-update.el
@@ -171,7 +171,7 @@ the match or nil."
        ((not (y-or-n-p (concat "Add " file " to the TAGS file? ")))
         (puthash file 1 etu/no-prompt-files)
         nil)
-       (t nil)))
+       (t t)))
      (t (error "Invalid etu/append-file-action action: %s" action)))))
 
 (defun etu/update-tags-for-file ()


### PR DESCRIPTION
It seems the logic in append-file-p isn't quite right -- if the user responds 'y' to the prompt, then the outer (cond) falls through to the (t nil) clause in the old code. This resulted in the function returning nil instead of t, so the file wouldn't be properly added.

This patch fixes the behavior to work as I expected (hitting y adds to the TAGS file and no longer prompted)
